### PR TITLE
Reset thread when conversation is stale

### DIFF
--- a/My workflow 3 (1) (2).json
+++ b/My workflow 3 (1) (2).json
@@ -674,6 +674,59 @@
     },
     {
       "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ (new Date().getTime()) - (new Date($json.last_message_at).getTime()) }}",
+              "rightValue": 86400000,
+              "operator": {
+                "type": "number",
+                "operation": "larger"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        -1920,
+        512
+      ],
+      "id": "f8dddcfd-042a-4525-aeb5-f2b186698895",
+      "name": "If stale conversation"
+    },
+    {
+      "parameters": {
+        "values": [
+          {
+            "name": "last_thread_id",
+            "value": "",
+            "type": "string",
+            "id": "fa91ce35-1dbe-4d1f-9d75-f300e84b1a5f"
+          }
+        ],
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -1760,
+        512
+      ],
+      "id": "ded1e401-bbac-4bd3-afb1-e95db6a55944",
+      "name": "Clear last thread id"
+    },
+    {
+      "parameters": {
         "mode": "combine",
         "combineBy": "combineByPosition",
         "options": {}
@@ -1041,6 +1094,35 @@
       ]
     },
     "Lookup1": {
+      "main": [
+        [
+          {
+            "node": "If stale conversation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "If stale conversation": {
+      "main": [
+        [
+          {
+            "node": "Clear last thread id",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Merge3",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Clear last thread id": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- add a conditional check after Lookup1 to compare `last_message_at` against the current time
- clear `last_thread_id` when the conversation is older than 24h to force a new thread

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb82c9e96c832388e8b6c84a043420